### PR TITLE
URL Rewrite 301 Redirect Bug Fixed

### DIFF
--- a/Job/Product.php
+++ b/Job/Product.php
@@ -3052,7 +3052,7 @@ class Product extends JobImport
                                     );
                                 }
                             } catch (\Exception $e) {
-                                $this->setAdditionalMessage(
+                                $this->jobExecutor->setAdditionalMessage(
                                     __(
                                         sprintf(
                                             'Tried to update url_rewrite_id %s : request path (%s) already exists for the store_id.',


### PR DESCRIPTION
It updates the old URL records as a 301 record when the product name changes.

https://github.com/akeneo/magento2-connector-community/issues/471